### PR TITLE
release: v1.0.45

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -143,16 +143,16 @@
         },
         {
             "name": "pdepend/pdepend",
-            "version": "2.9.1",
+            "version": "2.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pdepend/pdepend.git",
-                "reference": "1632f0cee84512ffd6dde71e58536b3b06528c41"
+                "reference": "1fd30f4352b630ad53fec3fd5e8b8ba760f85596"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1632f0cee84512ffd6dde71e58536b3b06528c41",
-                "reference": "1632f0cee84512ffd6dde71e58536b3b06528c41",
+                "url": "https://api.github.com/repos/pdepend/pdepend/zipball/1fd30f4352b630ad53fec3fd5e8b8ba760f85596",
+                "reference": "1fd30f4352b630ad53fec3fd5e8b8ba760f85596",
                 "shasum": ""
             },
             "require": {
@@ -188,7 +188,7 @@
             "description": "Official version of pdepend to be handled with Composer",
             "support": {
                 "issues": "https://github.com/pdepend/pdepend/issues",
-                "source": "https://github.com/pdepend/pdepend/tree/2.9.1"
+                "source": "https://github.com/pdepend/pdepend/tree/2.10.0"
             },
             "funding": [
                 {
@@ -196,7 +196,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-04-15T21:36:28+00:00"
+            "time": "2021-07-20T09:56:09+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -318,16 +318,16 @@
         },
         {
             "name": "phpcompatibility/phpcompatibility-wp",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCompatibility/PHPCompatibilityWP.git",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e"
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
-                "reference": "b7dc0cd7a8f767ccac5e7637550ea1c50a67b09e",
+                "url": "https://api.github.com/repos/PHPCompatibility/PHPCompatibilityWP/zipball/a792ab623069f0ce971b2417edef8d9632e32f75",
+                "reference": "a792ab623069f0ce971b2417edef8d9632e32f75",
                 "shasum": ""
             },
             "require": {
@@ -368,26 +368,26 @@
                 "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
                 "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
             },
-            "time": "2021-02-15T12:58:46+00:00"
+            "time": "2021-07-21T11:09:57+00:00"
         },
         {
             "name": "phpmd/phpmd",
-            "version": "2.10.1",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpmd/phpmd.git",
-                "reference": "bd5ef43d1dcaf7272605027c959c1c5ff3761f7a"
+                "reference": "1bc74db7cf834662d83abebae265be11bb2eec3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/bd5ef43d1dcaf7272605027c959c1c5ff3761f7a",
-                "reference": "bd5ef43d1dcaf7272605027c959c1c5ff3761f7a",
+                "url": "https://api.github.com/repos/phpmd/phpmd/zipball/1bc74db7cf834662d83abebae265be11bb2eec3a",
+                "reference": "1bc74db7cf834662d83abebae265be11bb2eec3a",
                 "shasum": ""
             },
             "require": {
                 "composer/xdebug-handler": "^1.0 || ^2.0",
                 "ext-xml": "*",
-                "pdepend/pdepend": "^2.9.1",
+                "pdepend/pdepend": "^2.10.0",
                 "php": ">=5.3.9"
             },
             "require-dev": {
@@ -443,7 +443,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/phpmd",
                 "issues": "https://github.com/phpmd/phpmd/issues",
-                "source": "https://github.com/phpmd/phpmd/tree/2.10.1"
+                "source": "https://github.com/phpmd/phpmd/tree/2.10.2"
             },
             "funding": [
                 {
@@ -451,7 +451,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-11T17:16:16+00:00"
+            "time": "2021-07-22T09:56:23+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
<!-- START pr-commits   please keep comment here to allow auto update -->
## Changes


* chore: update dependencies (49b539e42f8682ce89b3bc8bfc3b614b7182f6fb)

<!-- END pr-commits   please keep comment here to allow auto update -->

## Base PullRequest

default branch (https://github.com/wp-content-framework/session/tree/master)

## Command results
<details>
<summary>Details: </summary>

<details>
<summary><em>add path</em></summary>

```Shell
/home/runner/work/_actions/technote-space/create-pr-action/v2/node_modules/npm-check-updates/bin
```



</details>
<details>
<summary><em>composer prepare</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs

>> Copy files.
>>>> phpmd.xml
>>>> phpcs.xml
```

### stderr:

```Shell
> mkdir -p ./fixtures/.git
> chmod -R +w ./fixtures/.git && rm -rdf ./fixtures
> rm -f ./phpcs.xml ./phpmd.xml ./phpunit.xml
> git clone --depth=1 https://github.com/wp-content-framework/fixtures.git fixtures
Cloning into 'fixtures'...
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/prepare.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.10 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 19 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (2.0.1)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking pdepend/pdepend (2.10.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.2)
  - Locking phpmd/phpmd (2.10.2)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.4)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.3.3)
  - Locking symfony/dependency-injection (v5.3.3)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/filesystem (v5.3.3)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.0)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 19 installs, 0 updates, 0 removals
  - Downloading squizlabs/php_codesniffer (3.6.0)
  - Downloading dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Downloading phpcompatibility/php-compatibility (9.3.5)
  - Downloading phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Downloading phpcompatibility/phpcompatibility-wp (2.1.2)
  - Downloading symfony/polyfill-ctype (v1.23.0)
  - Downloading symfony/filesystem (v5.3.3)
  - Downloading psr/container (1.1.1)
  - Downloading symfony/service-contracts (v2.4.0)
  - Downloading symfony/polyfill-php80 (v1.23.0)
  - Downloading symfony/deprecation-contracts (v2.4.0)
  - Downloading symfony/dependency-injection (v5.3.3)
  - Downloading symfony/polyfill-php81 (v1.23.0)
  - Downloading symfony/config (v5.3.3)
  - Downloading pdepend/pdepend (2.10.0)
  - Downloading psr/log (1.1.4)
  - Downloading composer/xdebug-handler (2.0.1)
  - Downloading phpmd/phpmd (2.10.2)
  - Downloading wp-coding-standards/wpcs (2.3.0)
  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.2): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v5.3.3): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/dependency-injection (v5.3.3): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/config (v5.3.3): Extracting archive
  - Installing pdepend/pdepend (2.10.0): Extracting archive
  - Installing psr/log (1.1.4): Extracting archive
  - Installing composer/xdebug-handler (2.0.1): Extracting archive
  - Installing phpmd/phpmd (2.10.2): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
8 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Installing dependencies from lock file (including require-dev)
Verifying lock file contents can be installed on current platform.
Nothing to install, update or remove
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>
<details>
<summary><em>composer packages</em></summary>

```Shell
PHP CodeSniffer Config installed_paths set to ../../phpcompatibility/php-compatibility,../../phpcompatibility/phpcompatibility-paragonie,../../phpcompatibility/phpcompatibility-wp,../../wp-coding-standards/wpcs
```

### stderr:

```Shell
> WORKSPACE=${WORKSPACE:-$(cd $(dirname $0); pwd)} bash ./fixtures/bin/packages.sh
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
Using version ^0.7.1 for dealerdirect/phpcodesniffer-composer-installer
Using version ^2.10 for phpmd/phpmd
Using version ^3.6 for squizlabs/php_codesniffer
Using version ^2.3 for wp-coding-standards/wpcs
Using version ^2.1 for phpcompatibility/phpcompatibility-wp
./composer.json has been updated
Running composer update dealerdirect/phpcodesniffer-composer-installer phpmd/phpmd squizlabs/php_codesniffer wp-coding-standards/wpcs phpcompatibility/phpcompatibility-wp
Loading composer repositories with package information
Updating dependencies
Lock file operations: 19 installs, 0 updates, 0 removals
  - Locking composer/xdebug-handler (2.0.1)
  - Locking dealerdirect/phpcodesniffer-composer-installer (v0.7.1)
  - Locking pdepend/pdepend (2.10.0)
  - Locking phpcompatibility/php-compatibility (9.3.5)
  - Locking phpcompatibility/phpcompatibility-paragonie (1.3.1)
  - Locking phpcompatibility/phpcompatibility-wp (2.1.2)
  - Locking phpmd/phpmd (2.10.2)
  - Locking psr/container (1.1.1)
  - Locking psr/log (1.1.4)
  - Locking squizlabs/php_codesniffer (3.6.0)
  - Locking symfony/config (v5.3.3)
  - Locking symfony/dependency-injection (v5.3.3)
  - Locking symfony/deprecation-contracts (v2.4.0)
  - Locking symfony/filesystem (v5.3.3)
  - Locking symfony/polyfill-ctype (v1.23.0)
  - Locking symfony/polyfill-php80 (v1.23.0)
  - Locking symfony/polyfill-php81 (v1.23.0)
  - Locking symfony/service-contracts (v2.4.0)
  - Locking wp-coding-standards/wpcs (2.3.0)
Writing lock file
Installing dependencies from lock file (including require-dev)
Package operations: 19 installs, 0 updates, 0 removals
  - Installing squizlabs/php_codesniffer (3.6.0): Extracting archive
  - Installing dealerdirect/phpcodesniffer-composer-installer (v0.7.1): Extracting archive
  - Installing phpcompatibility/php-compatibility (9.3.5): Extracting archive
  - Installing phpcompatibility/phpcompatibility-paragonie (1.3.1): Extracting archive
  - Installing phpcompatibility/phpcompatibility-wp (2.1.2): Extracting archive
  - Installing symfony/polyfill-ctype (v1.23.0): Extracting archive
  - Installing symfony/filesystem (v5.3.3): Extracting archive
  - Installing psr/container (1.1.1): Extracting archive
  - Installing symfony/service-contracts (v2.4.0): Extracting archive
  - Installing symfony/polyfill-php80 (v1.23.0): Extracting archive
  - Installing symfony/deprecation-contracts (v2.4.0): Extracting archive
  - Installing symfony/dependency-injection (v5.3.3): Extracting archive
  - Installing symfony/polyfill-php81 (v1.23.0): Extracting archive
  - Installing symfony/config (v5.3.3): Extracting archive
  - Installing pdepend/pdepend (2.10.0): Extracting archive
  - Installing psr/log (1.1.4): Extracting archive
  - Installing composer/xdebug-handler (2.0.1): Extracting archive
  - Installing phpmd/phpmd (2.10.2): Extracting archive
  - Installing wp-coding-standards/wpcs (2.3.0): Extracting archive
8 package suggestions were added by new dependencies, use `composer suggest` to see details.
Generating autoload files
11 packages you are using are looking for funding.
Use the `composer fund` command to find out more!
```

</details>

</details>

## Changed files
<details>
<summary>Changed file: </summary>

- composer.lock

</details>

<hr>

[:octocat: Repo](https://github.com/technote-space/create-pr-action) | [:memo: Issues](https://github.com/technote-space/create-pr-action/issues) | [:department_store: Marketplace](https://github.com/marketplace/actions/create-pr-action)